### PR TITLE
Add "file://" scheme

### DIFF
--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -64,7 +64,9 @@ if (!mapFilePath || !distDirPath) {
 }
 
 const distDir = path.resolve(process.cwd(), distDirPath)
-const mapFile = await import(path.resolve(process.cwd(), mapFilePath))
+let mapFilePathAbs = path.resolve(process.cwd(), mapFilePath)
+if (process.platform === 'win32') mapFilePathAbs = 'file://' + mapFilePathAbs // On Windows, absolute paths must be valid file:// URLs
+const mapFile = await import(mapFilePathAbs)
 
 // Determine the blueprints that are being built
 let sources = mapFile.BlueprintEntrypoints


### PR DESCRIPTION
When running this on Windows, I get this error:

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are suppo rted by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'