### PR TITLE
Fix: update the export for assets

### DIFF
--- a/lib/rollup/urlPlugin.mjs
+++ b/lib/rollup/urlPlugin.mjs
@@ -9,7 +9,7 @@ import fs from 'node:fs/promises'
  * In the process of this, it has been refactored and simplified a lot.
  * @returns {import('rollup').Plugin}
  */
-export const urlPluginExt = (destDir) => {
+export const urlPluginExt = (/** @type {string} */ destDir) => {
 	const include = ['**/*.svg', '**/*.png', '**/*.gif']
 	const sourceDir = null // TODO?
 	const fileName = '[hash][extname]'
@@ -45,13 +45,13 @@ export const urlPluginExt = (destDir) => {
 					.replace(/\[dirname\]/g, relativeDir === '' ? '' : `${relativeDir}${path.sep}`)
 					.replace(/\[name\]/g, name)
 				// Windows fix - exports must be in unix format
-				const data = `${outputFileName.split(path.sep).join(path.posix.sep)}`
+				const data = `${path.join(destDir, outputFileName).split(path.sep).join(path.posix.sep)}`
 				copies[id] = outputFileName
 
 				// Emit the file so that it gets copied and our bundler plugin detects it
 				this.emitFile({
-					name: data,
-					fileName: path.join(destDir, data),
+					name: outputFileName,
+					fileName: data,
 					originalFileName: id,
 					source: buffer,
 					type: 'asset',


### PR DESCRIPTION
Update the export for assets to include the asset directory name so that it matches the path used in the bundle.
