### PR TITLE
fix: use prettier.resolveConfig to look up config file

### DIFF
--- a/bin/schema-types.mjs
+++ b/bin/schema-types.mjs
@@ -2,7 +2,7 @@
 import { compileFromFile } from 'json-schema-to-typescript'
 import * as fs from 'fs/promises'
 import meow from 'meow'
-import { createRequire } from 'module'
+import prettier from 'prettier'
 import path from 'path'
 
 /** ********************************************************
@@ -18,7 +18,7 @@ const cli = meow(
 
 	Usage
 		$ blueprint-schema-types <search-path> <output-path>
-    
+
 	Examples
 		$ blueprint-schema-types ./src/$schemas/generated ./src/generated/types
 `,
@@ -40,9 +40,7 @@ const BANNER =
 
 let PrettierConf = undefined
 try {
-	const require = createRequire(import.meta.url)
-	const confPath = require.resolve('@sofie-automation/code-standard-preset/.prettierrc.json')
-	PrettierConf = JSON.parse(await fs.readFile(confPath, 'utf8'))
+	PrettierConf = (await prettier.resolveConfig('@sofie-automation/code-standard-preset')) ?? undefined
 } catch (e) {
 	console.log(e)
 	console.warn(`Failed to resolve prettier config path, skipping prettier formatting`)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"i18next-parser": "^9.4.0",
 		"json-schema-to-typescript": "^15.0.4",
 		"meow": "^14.1.0",
+		"prettier": "^3.8.1",
 		"rollup": "^4.61.0",
 		"vinyl-fs": "^4.0.2"
 	},

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
 		"i18next-parser": "^9.4.0",
 		"json-schema-to-typescript": "^15.0.4",
 		"meow": "^14.1.0",
-		"prettier": "^3.8.1",
 		"rollup": "^4.61.0",
 		"vinyl-fs": "^4.0.2"
 	},
 	"peerDependencies": {
-		"@sofie-automation/blueprints-integration": "*"
+		"@sofie-automation/blueprints-integration": "*",
+		"prettier": "*"
 	},
 	"devDependencies": {
 		"@sofie-automation/blueprints-integration": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,15 +2823,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.8.1":
-  version: 3.8.4
-  resolution: "prettier@npm:3.8.4"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10c0/b90a0cbe75b88ac0af9c13fe0f359bd19926fabccd88483227b21f71f0c1cc42da056fc1ac3a361e665577c568371d5ccfb2c62c31c8a1186f8d1bd531a063e9
-  languageName: node
-  linkType: hard
-
 "proc-log@npm:^6.0.0":
   version: 6.0.0
   resolution: "proc-log@npm:6.0.0"
@@ -3274,11 +3265,11 @@ __metadata:
     i18next-parser: "npm:^9.4.0"
     json-schema-to-typescript: "npm:^15.0.4"
     meow: "npm:^14.1.0"
-    prettier: "npm:^3.8.1"
     rollup: "npm:^4.61.0"
     vinyl-fs: "npm:^4.0.2"
   peerDependencies:
     "@sofie-automation/blueprints-integration": "*"
+    prettier: "*"
   bin:
     blueprint-build: bin/build.mjs
     blueprint-bundle: bin/bundle.mjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,6 +2823,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^3.8.1":
+  version: 3.8.4
+  resolution: "prettier@npm:3.8.4"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/b90a0cbe75b88ac0af9c13fe0f359bd19926fabccd88483227b21f71f0c1cc42da056fc1ac3a361e665577c568371d5ccfb2c62c31c8a1186f8d1bd531a063e9
+  languageName: node
+  linkType: hard
+
 "proc-log@npm:^6.0.0":
   version: 6.0.0
   resolution: "proc-log@npm:6.0.0"
@@ -3265,6 +3274,7 @@ __metadata:
     i18next-parser: "npm:^9.4.0"
     json-schema-to-typescript: "npm:^15.0.4"
     meow: "npm:^14.1.0"
+    prettier: "npm:^3.8.1"
     rollup: "npm:^4.61.0"
     vinyl-fs: "npm:^4.0.2"
   peerDependencies:


### PR DESCRIPTION
.prettierrc.json was removed from sofie-code-standard-preset in May. Using `prettier.resolveConfig` to look up config file, supports both the old file, and the new.


replaces #26